### PR TITLE
Dark Mode Toggle Working across all pages

### DIFF
--- a/body.html
+++ b/body.html
@@ -4,10 +4,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Body - Byom</title>
-    <link rel="stylesheet" href="styles.css">
-    <link rel="stylesheet" href="page-styles.css">
+    <link id="theme-link-main" rel="stylesheet" href="styles.css">
+    <link id="theme-link-page" rel="stylesheet" href="page-styles.css">    
 </head>
 <body>
+     <button id="theme-toggle" class="theme-toggle">🌙</button>
     <div class="container page-container">
         <nav class="navigation">
             <a href="index.html" class="nav-home">🕉️ Byom</a>
@@ -103,4 +104,5 @@
         </footer>
     </div>
 </body>
+<script src="script.js"></script>
 </html>

--- a/dark-ps.css
+++ b/dark-ps.css
@@ -1,0 +1,267 @@
+/* 🌑 Clean Dark Mode Styles — No more purple */
+
+.page-container {
+    background: radial-gradient(circle at top left, #0a0a0a 0%, #0d1117 60%, #000 100%);
+    min-height: 100vh;
+    padding: 0;
+    color: #e0e0e0;
+}
+
+/* Navigation */
+.navigation {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 20px 40px;
+    background: rgba(15, 15, 15, 0.9);
+    backdrop-filter: blur(10px);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.nav-home {
+    font-size: 1.5rem;
+    color: #fff;
+    text-decoration: none;
+    font-weight: 600;
+    transition: all 0.3s ease;
+}
+
+.nav-home:hover {
+    transform: scale(1.05);
+    text-shadow: 0 0 10px rgba(100, 200, 255, 0.5);
+}
+
+.nav-links {
+    display: flex;
+    gap: 30px;
+}
+
+.nav-link {
+    color: rgba(255, 255, 255, 0.7);
+    text-decoration: none;
+    padding: 10px 20px;
+    border-radius: 25px;
+    transition: all 0.3s ease;
+    font-weight: 500;
+}
+
+.nav-link:hover,
+.nav-link.active {
+    background: rgba(255, 255, 255, 0.1);
+    color: #fff;
+    transform: translateY(-2px);
+}
+
+/* Page Content */
+.page-content {
+    padding: 40px;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.page-header {
+    text-align: center;
+    margin-bottom: 50px;
+    color: #fff;
+}
+
+.page-icon {
+    font-size: 4rem;
+    margin-bottom: 20px;
+    display: block;
+    filter: drop-shadow(0 4px 8px rgba(80, 180, 255, 0.4));
+}
+
+.page-title {
+    font-size: 3rem;
+    margin-bottom: 10px;
+    text-shadow: 0 4px 8px rgba(0, 0, 0, 0.6);
+    font-weight: 300;
+}
+
+.page-subtitle {
+    font-size: 1.3rem;
+    opacity: 0.85;
+    font-weight: 300;
+}
+
+/* Content Grid */
+.content-grid {
+    display: grid;
+    gap: 30px;
+    grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+}
+
+.content-card {
+    background: #111827;
+    padding: 30px;
+    border-radius: 20px;
+    box-shadow: 0 15px 25px rgba(0, 0, 0, 0.5);
+    transition: transform 0.3s ease, background 0.3s ease;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.content-card:hover {
+    transform: translateY(-5px);
+    background: #1b2430;
+}
+
+.content-card h2,
+.content-card h3,
+.content-card h4 {
+    color: #aee1f9;
+}
+
+.content-card p,
+.content-card li {
+    color: #b0b0b0;
+    line-height: 1.7;
+}
+
+.content-card li:before {
+    content: "✦";
+    color: #66c2ff;
+}
+
+/* Practice Grid */
+.practice-grid,
+.daily-practices {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 20px;
+    margin-top: 20px;
+}
+
+.practice-item {
+    background: #161b22;
+    padding: 20px;
+    border-radius: 15px;
+    text-align: center;
+    transition: transform 0.3s ease, background 0.3s ease;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.practice-item:hover {
+    transform: scale(1.05);
+    background: #1d2330;
+}
+
+.practice-item h4 {
+    color: #80d0ff;
+}
+
+.practice-item p {
+    color: #aaa;
+}
+
+/* Daily Practices */
+.practice-time {
+    background: linear-gradient(135deg, #0f2027 0%, #203a43 50%, #2c5364 100%);
+    color: white;
+    padding: 20px;
+    border-radius: 15px;
+    text-align: center;
+    transition: transform 0.3s ease;
+}
+
+.practice-time:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 8px 20px rgba(50, 100, 200, 0.3);
+}
+
+.practice-time h4 {
+    color: #b0dcff;
+}
+
+/* Blockquotes */
+blockquote {
+    background: #111;
+    border-left: 4px solid #66c2ff;
+    padding: 20px;
+    margin: 20px 0;
+    border-radius: 0 10px 10px 0;
+    font-style: italic;
+    color: #ccc;
+    position: relative;
+}
+
+blockquote:before {
+    content: "\201C";
+    font-size: 4rem;
+    color: #66c2ff;
+    position: absolute;
+    top: -10px;
+    left: 10px;
+    opacity: 0.3;
+}
+
+cite {
+    display: block;
+    text-align: right;
+    margin-top: 15px;
+    font-weight: 600;
+    color: #80d0ff;
+}
+
+/* Footer */
+.page-footer {
+    text-align: center;
+    padding: 40px;
+    margin-top: 50px;
+    background: #0d1117;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    color: #aaa;
+}
+
+.footer-link {
+    color: rgba(255, 255, 255, 0.7);
+    text-decoration: none;
+    padding: 12px 25px;
+    border: 2px solid rgba(255, 255, 255, 0.15);
+    border-radius: 25px;
+    transition: all 0.3s ease;
+}
+
+.footer-link:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: white;
+    border-color: rgba(255, 255, 255, 0.3);
+    transform: translateY(-2px);
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .navigation {
+        flex-direction: column;
+        gap: 20px;
+    }
+
+    .content-grid,
+    .practice-grid,
+    .daily-practices {
+        grid-template-columns: 1fr;
+    }
+
+    .page-title {
+        font-size: 2.4rem;
+    }
+}
+.theme-toggle {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    padding: 10px 15px;
+    border: none;
+    border-radius: 10px;
+    background: rgba(255,255,255,0.2);
+    color: #fff;
+    font-size: 1.2rem;
+    cursor: pointer;
+    z-index: 999;
+    transition: all 0.3s ease;
+}
+
+.theme-toggle:hover {
+    background: rgba(255,255,255,0.35);
+    transform: scale(1.1);
+}

--- a/darkstyles.css
+++ b/darkstyles.css
@@ -1,0 +1,296 @@
+/* Reset and Base Styles */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background: radial-gradient(circle at top left, #0f2027, #203a43, #2c5364);
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #eaeaea;
+}
+
+.container {
+    width: 100%;
+    max-width: 1200px;
+    padding: 20px;
+    text-align: center;
+}
+
+/* Header */
+header {
+    margin-bottom: 40px;
+}
+
+.title {
+    font-size: 3.5rem;
+    color: #f0f0f0;
+    margin-bottom: 10px;
+    font-weight: 300;
+    letter-spacing: 2px;
+    text-shadow: 0 4px 10px rgba(0, 0, 0, 0.6);
+}
+
+.subtitle {
+    font-size: 1.2rem;
+    color: rgba(255, 255, 255, 0.8);
+}
+
+/* Om Container */
+.om-container {
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 20px;
+    padding: 40px;
+    box-shadow: 0 25px 45px rgba(0, 0, 0, 0.3);
+    backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    margin-bottom: 30px;
+}
+
+.om-symbol-wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-bottom: 40px;
+    position: relative;
+    height: 160px;
+    max-width: 400px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.om-text {
+    font-size: 10rem;
+    color: #eaeaea;
+    text-shadow: 0 0 30px rgba(255, 255, 255, 0.15);
+    font-family: 'Noto Sans Devanagari', serif;
+    transition: all 0.3s ease;
+    pointer-events: none; /* so hover works */
+    z-index: 2;
+}
+
+/* SVG overlay */
+.om-overlay {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 1;
+    pointer-events: all;
+}
+
+/* Clickable / Interactions */
+.clickable {
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.clickable:hover {
+    transform: scale(1.05);
+    filter: brightness(1.2);
+}
+
+/* Interactive Zones */
+.interactive-zone {
+    transition: all 0.3s ease;
+    border-radius: 50%;
+    opacity: 0.08;
+}
+
+.soul-section:hover .soul-zone {
+    opacity: 0.7;
+    stroke: #9b59b6;
+    animation: glow 2s ease-in-out infinite;
+}
+
+.mind-section:hover .mind-zone {
+    opacity: 0.7;
+    stroke: #3498db;
+    animation: glow 2s ease-in-out infinite;
+}
+
+.body-section:hover .body-zone {
+    opacity: 0.7;
+    stroke: #2ecc71;
+    animation: glow 2s ease-in-out infinite;
+}
+
+/* Zone indicators */
+.zone-indicator {
+    transition: all 0.3s ease;
+    opacity: 0.3;
+}
+
+.soul-section:hover .zone-indicator {
+    stroke: #9b59b6;
+    stroke-width: 2;
+    animation: fastPulse 1s infinite;
+}
+
+.mind-section:hover .zone-indicator {
+    stroke: #3498db;
+    stroke-width: 2;
+    animation: fastPulse 1s infinite;
+}
+
+.body-section:hover .zone-indicator {
+    stroke: #2ecc71;
+    stroke-width: 2;
+    animation: fastPulse 1s infinite;
+}
+
+/* Animations */
+@keyframes glow {
+    0% { opacity: 0.6; transform: scale(1); }
+    50% { opacity: 0.9; transform: scale(1.05); }
+    100% { opacity: 0.6; transform: scale(1); }
+}
+
+@keyframes fastPulse {
+    0%, 100% { opacity: 0.6; }
+    50% { opacity: 1; }
+}
+
+@keyframes subtlePulse {
+    0%, 100% { opacity: 0.08; }
+    50% { opacity: 0.18; }
+}
+
+/* Sections Info */
+.sections-info {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 20px;
+    margin-top: 30px;
+}
+
+.section-card {
+    background: rgba(255, 255, 255, 0.05);
+    padding: 25px;
+    border-radius: 15px;
+    backdrop-filter: blur(8px);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+    transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+}
+
+.section-card:hover {
+    transform: translateY(-5px);
+    background: rgba(255, 255, 255, 0.1);
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
+}
+
+/* Card Om */
+.card-om {
+    font-size: 3rem;
+    color: rgba(255, 255, 255, 0.4);
+    font-family: 'Noto Sans Devanagari', serif;
+    margin-bottom: 15px;
+    transition: all 0.3s ease;
+}
+
+/* Hover Colors */
+.soul-card:hover {
+    border: 1px solid #9b59b6;
+    box-shadow: 0 0 25px rgba(155, 89, 182, 0.3);
+}
+
+.soul-card:hover .card-om {
+    color: #9b59b6;
+    text-shadow: 0 0 20px rgba(155, 89, 182, 0.6);
+}
+
+.mind-card:hover {
+    border: 1px solid #3498db;
+    box-shadow: 0 0 25px rgba(52, 152, 219, 0.3);
+}
+
+.mind-card:hover .card-om {
+    color: #3498db;
+    text-shadow: 0 0 20px rgba(52, 152, 219, 0.6);
+}
+
+.body-card:hover {
+    border: 1px solid #2ecc71;
+    box-shadow: 0 0 25px rgba(46, 204, 113, 0.3);
+}
+
+.body-card:hover .card-om {
+    color: #2ecc71;
+    text-shadow: 0 0 20px rgba(46, 204, 113, 0.6);
+}
+
+.section-card h3 {
+    font-size: 1.5rem;
+    color: #f1f1f1;
+}
+
+.section-card p {
+    color: #aaa;
+}
+
+/* Tooltip */
+.tooltip {
+    position: fixed;
+    background: rgba(0,0,0,0.85);
+    color: white;
+    padding: 10px 14px;
+    border-radius: 8px;
+    font-size: 0.95rem;
+    pointer-events: none;
+    z-index: 1000;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    white-space: nowrap;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+    border: 1px solid rgba(255,255,255,0.1);
+}
+
+.tooltip.show {
+    opacity: 1;
+}
+
+/* Footer */
+footer .quote {
+    font-style: italic;
+    color: #f0f0f0;
+    opacity: 0.9;
+    text-shadow: 0 2px 6px rgba(0,0,0,0.4);
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .title { font-size: 2.5rem; }
+    .om-text { font-size: 7rem; }
+    .sections-info { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 480px) {
+    .title { font-size: 2rem; }
+    .om-text { font-size: 5rem; }
+}
+
+.theme-toggle {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    padding: 10px 15px;
+    border: none;
+    border-radius: 10px;
+    background: rgba(255,255,255,0.2);
+    color: #fff;
+    font-size: 1.2rem;
+    cursor: pointer;
+    z-index: 999;
+    transition: all 0.3s ease;
+}
+
+.theme-toggle:hover {
+    background: rgba(255,255,255,0.35);
+    transform: scale(1.1);
+}

--- a/index.html
+++ b/index.html
@@ -7,9 +7,11 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+Devanagari:wght@400;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css">
+    <link id="theme-link-main" rel="stylesheet" href="styles.css">
+    <link id="theme-link-page" rel="stylesheet" href="page-styles.css">
 </head>
 <body>
+    <button id="theme-toggle" class="theme-toggle">🌙</button>
     <div class="container">
         <header>
             <h1 class="title">Byom</h1>

--- a/mind.html
+++ b/mind.html
@@ -4,10 +4,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mind - Byom</title>
-    <link rel="stylesheet" href="styles.css">
-    <link rel="stylesheet" href="page-styles.css">
+    <link id="theme-link-main" rel="stylesheet" href="styles.css">
+    <link id="theme-link-page" rel="stylesheet" href="page-styles.css">
 </head>
 <body>
+     <button id="theme-toggle" class="theme-toggle">🌙</button>
     <div class="container page-container">
         <nav class="navigation">
             <a href="index.html" class="nav-home">🕉️ Byom</a>
@@ -103,4 +104,5 @@
         </footer>
     </div>
 </body>
+<script src="script.js"></script>
 </html>

--- a/page-styles.css
+++ b/page-styles.css
@@ -345,3 +345,22 @@ cite {
         padding: 15px;
     }
 }
+.theme-toggle {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    padding: 10px 15px;
+    border: none;
+    border-radius: 10px;
+    background: rgba(255,255,255,0.2);
+    color: #fff;
+    font-size: 1.2rem;
+    cursor: pointer;
+    z-index: 999;
+    transition: all 0.3s ease;
+}
+
+.theme-toggle:hover {
+    background: rgba(255,255,255,0.35);
+    transform: scale(1.1);
+}

--- a/script.js
+++ b/script.js
@@ -13,12 +13,16 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     // Tooltip functionality
-    function showTooltip(event, text) {
-        tooltip.textContent = text;
-        tooltip.style.left = event.pageX + 10 + 'px';
-        tooltip.style.top = event.pageY - 30 + 'px';
-        tooltip.classList.add('show');
-    }
+function showTooltip(event, text) {
+  tooltip.textContent = text;
+  // use client coords since tooltip is position: fixed
+  const x = event.clientX + 10;
+  const y = event.clientY - 30;
+  tooltip.style.left = x + 'px';
+  tooltip.style.top = y + 'px';
+  tooltip.classList.add('show');
+}
+
 
     function hideTooltip() {
         tooltip.classList.remove('show');
@@ -136,3 +140,45 @@ document.addEventListener('DOMContentLoaded', function() {
         footer.appendChild(keyboardHint);
     }
 });
+
+const toggleBtn = document.getElementById('theme-toggle');
+const mainCSS = document.getElementById('theme-link-main');
+const pageCSS = document.getElementById('theme-link-page'); // can be null
+
+// function to apply theme
+function applyTheme(theme) {
+    // main CSS
+    if (mainCSS) {
+        mainCSS.href = theme === 'dark' ? 'darkstyles.css' : 'styles.css';
+    }
+
+    // page CSS
+    if (pageCSS) {
+        if (pageCSS.href) { // only if page CSS exists
+            pageCSS.href = theme === 'dark' ? 'dark-ps.css' : 'page-styles.css';
+        }
+    }
+
+    // button icon
+    toggleBtn.textContent = theme === 'dark' ? '☀️' : '🌙';
+
+    // save to localStorage
+    localStorage.setItem('theme', theme);
+}
+
+// toggle on click
+toggleBtn.addEventListener('click', () => {
+    const currentTheme = localStorage.getItem('theme') || 'light';
+    const newTheme = currentTheme === 'light' ? 'dark' : 'light';
+    applyTheme(newTheme);
+});
+
+// on load, apply saved theme
+document.addEventListener('DOMContentLoaded', () => {
+    const savedTheme = localStorage.getItem('theme') || 'light';
+    applyTheme(savedTheme);
+});
+
+
+
+

--- a/soul.html
+++ b/soul.html
@@ -4,10 +4,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Soul - Byom</title>
-    <link rel="stylesheet" href="styles.css">
-    <link rel="stylesheet" href="page-styles.css">
+    <link id="theme-link-main" rel="stylesheet" href="styles.css">
+    <link id="theme-link-page" rel="stylesheet" href="page-styles.css">
 </head>
 <body>
+     <button id="theme-toggle" class="theme-toggle">🌙</button>
     <div class="container page-container">
         <nav class="navigation">
             <a href="index.html" class="nav-home">🕉️ Byom</a>
@@ -103,4 +104,5 @@
         </footer>
     </div>
 </body>
+<script src="script.js"></script>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -393,3 +393,23 @@ footer {
         padding: 15px;
     }
 }
+
+.theme-toggle {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    padding: 10px 15px;
+    border: none;
+    border-radius: 10px;
+    background: rgba(255,255,255,0.2);
+    color: #fff;
+    font-size: 1.2rem;
+    cursor: pointer;
+    z-index: 999;
+    transition: all 0.3s ease;
+}
+
+.theme-toggle:hover {
+    background: rgba(255,255,255,0.35);
+    transform: scale(1.1);
+}


### PR DESCRIPTION
Summary:
Added a site-wide dark mode toggle that works across all pages (index.html, mind.html, body.html, soul.html). Users can switch between light and dark themes using a floating button 🌙 / ☀️. The theme preference persists across sessions using localStorage.

Changes Made:

CSS:
Created darkstyles.css (dark version of styles.css)
Created dark-ps.css (dark version of page-styles.css)
Updated colors, backgrounds, hover states, and tooltips for dark mode

JS (script.js):
Added a single toggle function that swaps main and page-specific CSS files
Button updates icon depending on current theme
Saves user preference in localStorage to persist between visits
Works across all pages, dynamically handling missing page-specific CSS

HTML Updates:
Added id="theme-link-main" and id="theme-link-page" to <link> tags
Added toggle button <button id="theme-toggle">🌙</button> positioned in top-right corner

Benefits:
Modernizes UI with dark theme for night-time use
Maintains accessibility and readability
Light and dark modes consistent across site

Testing / Notes:
Verified toggle on desktop 
Checked persistence after refresh
Hover effects and interactive Om symbol work correctly in both themes